### PR TITLE
"," needs to be allowed to allow for multiple inheritance.

### DIFF
--- a/Syntaxes/C++.plist
+++ b/Syntaxes/C++.plist
@@ -413,7 +413,7 @@
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?&lt;=\})|(?=(;|,|\(|\)|&gt;|\[|\]|=))</string>
+					<string>(?&lt;=\})|(?=(;|\(|\)|&gt;|\[|\]|=))</string>
 					<key>name</key>
 					<string>meta.class-struct-block.c++</string>
 					<key>patterns</key>


### PR DESCRIPTION
Otherwise we'll end up with a situation like this:

``` c++
class A {};
class B {};
class Test : public A, public B
{
public:
    Test() {}
    ~Test() {}

    void this_isnt_detected_as_a_function(int a, int b) {}
    int neither_is_this() {return 1;}
};
```

If "," is allowed, then all functions in this example are detected correctly.
