### PR TITLE
Give parens punctuation.section.parens.begin/end scope

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -743,8 +743,24 @@
 		<dict>
 			<key>begin</key>
 			<string>\(</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.begin</string>
+				</dict>
+			</dict>
 			<key>end</key>
 			<string>\)</string>
+			<key>endCaptures</key>
+			<dict>
+				<key>0</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.section.parens.end</string>
+				</dict>
+			</dict>
 			<key>name</key>
 			<string>meta.parens.c</string>
 			<key>patterns</key>


### PR DESCRIPTION
This allows "Source/Other Actions/Return Inside Empty Item" to work for parenthesis as well.
