### PR TITLE
Common type idiom + sizeof/1 as library function

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -376,11 +376,11 @@
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>common C type naming idiom -- custom_type_t</string>
-      <key>match</key>
-      <string>\b([a-z0-9_]+_t)\b</string>
-      <key>name</key>
-      <string>support.type.custom.c</string>
+			<string>Reserved POSIX types</string>
+			<key>match</key>
+			<string>\b([a-z0-9_]+_t)\b</string>
+			<key>name</key>
+			<string>support.type.posix-reserved.c</string>
     </dict>
     <dict>
 			<key>include</key>


### PR DESCRIPTION
We can now correctly highlight custom types suffixed with `_t`, a common idiom in C. The syntax highlighter GitHub uses already does it right:

``` C
custom_type_t variable = {};
```

Additionally, the `sizeof` operator is treated different than the `sizeof/1` function. However, the `sizeof/1` function is now recognized as a library function (and thus not user function), for correct syntax highlighting.
