### PR TITLE
Corrected keyword highlighting of sizeof within function calls

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -395,7 +395,7 @@
     		       | (?= \s*[A-Za-z_] ) (?&lt;!&amp;&amp;)       (?&lt;=[*&amp;&gt;])   #  or type modifier before name
     		     )
     		)
-    		(\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|[cr]?iterate)\s*\()
+    		(\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate)\s*\()
     		(
     			(?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++ |                  # actual name
     			(?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator


### PR DESCRIPTION
Added `sizeof(...)` to the ignore list for keywords in function calls, so that placing `sizeof(...)` into the parentheses of a function call will now highlight correctly.

``` C
int *var = malloc(10 * sizeof(int));
```
