### PR TITLE
Reformat Document using clang-format

### DIFF
--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/bin/bash
+if ! "${TM_CLANG_FORMAT}" -style="${TM_CLANG_FORMAT_STYLE-LLVM}"; then
+	. "$TM_SUPPORT_PATH/lib/bash_init.sh"
+	exit_show_tool_tip
+fi
+</string>
+	<key>input</key>
+	<string>document</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>^H</string>
+	<key>name</key>
+	<string>Reformat Document</string>
+	<key>outputCaret</key>
+	<string>interpolateByLine</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>replaceDocument</string>
+	<key>requiredCommands</key>
+	<array>
+		<dict>
+			<key>command</key>
+			<string>clang-format</string>
+			<key>locations</key>
+			<array>
+				<string>/usr/local/bin/clang-format</string>
+			</array>
+			<key>moreInfoURL</key>
+			<string>http://clang.llvm.org/docs/ClangFormat.html</string>
+			<key>variable</key>
+			<string>TM_CLANG_FORMAT</string>
+		</dict>
+	</array>
+	<key>scope</key>
+	<string>source.c, source.objc, source.c++, source.objc++</string>
+	<key>uuid</key>
+	<string>24966EE2-1BC4-4995-B39F-F6F9461184F5</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/info.plist
+++ b/info.plist
@@ -45,6 +45,8 @@
 			<string>5A086BE2-BCF6-11D9-82A9-000D93589AF6</string>
 			<string>FE378349-BD63-4390-9A3B-516F7FF7F413</string>
 			<string>3D221F96-F4CC-432D-9A04-F9F4DF3E0F55</string>
+			<string>------------------------------------</string>
+			<string>24966EE2-1BC4-4995-B39F-F6F9461184F5</string>
 		</array>
 		<key>submenus</key>
 		<dict>


### PR DESCRIPTION
http://clang.llvm.org/docs/ClangFormat.html
- Passes `-style` argument using `TM_CLANG_FORMAT_STYLE` variable.
- Uses `TM_CLANG_FORMAT_STYLE` path otherwise `/usr/bin/env clang-format`
