### PR TITLE
Append -assume-filename=<path> to clang-format

### DIFF
--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/bash
-if ! "${TM_CLANG_FORMAT}" -style="${TM_CLANG_FORMAT_STYLE-LLVM}"; then
+if ! "${TM_CLANG_FORMAT}" -style="${TM_CLANG_FORMAT_STYLE-LLVM}" -assume-filename="${TM_FILEPATH}"; then
 	. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 	exit_show_tool_tip
 fi


### PR DESCRIPTION
This makes 'file' style to work, as clang-format needs to know file path to
resolve possible .clang-format style definition files placement.
