### PR TITLE
grammar: Use explicit count modifiers

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -1142,7 +1142,7 @@
 			<array>
 				<dict>
 					<key>match</key>
-					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{,2}|[4-7]\d?|x[a-fA-F0-9]{,2}|u[a-fA-F0-9]{,4}|U[a-fA-F0-9]{,8})</string>
+					<string>\\(\\|[abefnprtv'"?]|[0-3]\d{0,2}|[4-7]\d?|x[a-fA-F0-9]{0,2}|u[a-fA-F0-9]{0,4}|U[a-fA-F0-9]{0,8})</string>
 					<key>name</key>
 					<string>constant.character.escape.c</string>
 				</dict>


### PR DESCRIPTION
The `{,N}` extension is not supported by most regexp engines, as it is an Onigurma-only extension. If it's not too painful, it'd be super-nice to have `{0,N}` in the grammar so we can use it on PCRE-based engines too.

Obviously behavior should be identical.

cc @sorbits 
