### PR TITLE
Add `noexcept` to the list of storage modifiers

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -432,7 +432,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b(const|final|override)\b</string>
+					<string>\b(const|final|override|noexcept)\b</string>
 					<key>name</key>
 					<string>storage.modifier.$1.c++</string>
 				</dict>


### PR DESCRIPTION
`noexcept` is a storage modifier in C++11, but is not listed in the `plist`. As a result, this does not syntax-highlight properly on GitHub:

```cpp
class foo
{
public:
    void bar() const noexcept;
};
```

This PR fixes that by adding it to the grammar.