### PR TITLE
Use $self instead of $base

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -240,7 +240,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>$base</string>
+					<string>$self</string>
 				</dict>
 			</array>
 		</dict>
@@ -567,7 +567,7 @@
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>$base</string>
+					<string>$self</string>
 				</dict>
 			</array>
 		</dict>
@@ -754,7 +754,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>$base</string>
+					<string>$self</string>
 				</dict>
 			</array>
 		</dict>
@@ -831,7 +831,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>$base</string>
+							<string>$self</string>
 						</dict>
 					</array>
 				</dict>
@@ -996,7 +996,7 @@
 					<array>
 						<dict>
 							<key>include</key>
-							<string>$base</string>
+							<string>$self</string>
 						</dict>
 					</array>
 				</dict>
@@ -1098,7 +1098,7 @@
 			<array>
 				<dict>
 					<key>include</key>
-					<string>$base</string>
+					<string>$self</string>
 				</dict>
 			</array>
 		</dict>


### PR DESCRIPTION
To be totally open, I’m not a TextMate user, so I haven’t tested this change in TextMate, but I believe this works.

This pull request replaces `$base` with `$self` in the C grammar. My motivation for this change is to improve how [GitHub Linguist](https://github.com/github/linguist) highlights C that’s embedded in another language. Using `$base` can make the syntax highlighter use the language that contains C, even when the C highlighter should still be used.

For an extreme example, [luaopcode.csd](https://github.com/csound/manual/blob/master/examples/luaopcode.csd) in the [Csound manual repository](https://github.com/csound/manual) contains C embedded in Lua embedded in Csound. [Line&nbsp;11](https://github.com/csound/manual/blob/master/examples/luaopcode.csd#L11) is in C, but at the first `;` in this line, the syntax highlighting looks like a comment. I believe this is because using `$base` (probably at [line&nbsp;570 of the C grammar](https://github.com/textmate/c.tmbundle/blob/master/Syntaxes/C.plist#L570)) restores highlighting to Csound, which uses `;` to start single-line comments.