### PR TITLE
Drop "invalid.illegal.placeholder.c" definition

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -1172,12 +1172,6 @@
 					<key>name</key>
 					<string>constant.other.placeholder.c</string>
 				</dict>
-				<dict>
-					<key>match</key>
-					<string>%</string>
-					<key>name</key>
-					<string>invalid.illegal.placeholder.c</string>
-				</dict>
 			</array>
 		</dict>
 	</dict>


### PR DESCRIPTION
It's often misleading (I have plenty of lone %s in strings), and only the compiler knows when it's right to complain about an actual format string with a bad placeholder.

🙇 
