### PR TITLE
Add `->` variable access.

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -461,7 +461,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\.)([a-zA-Z_][a-zA-Z_0-9]*)\b(?!\s*\()</string>
+			<string>(\.|\-&gt;)([a-zA-Z_][a-zA-Z_0-9]*)\b(?!\s*\()</string>
 		</dict>
 		<key>block</key>
 		<dict>


### PR DESCRIPTION
Since

```c
(*struct_ptr).var = 123;
```

is the same as

```c
struct_ptr->var = 123;
```

`->` should also be colored the same as `.`.