### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/C++.plist
+++ b/Syntaxes/C++.plist
@@ -613,7 +613,7 @@
 					<array>
 						<dict>
 							<key>match</key>
-							<string>\\u\h{4}|\\U\h{8}</string>
+							<string>\\u[0-9A-Fa-f]{4}|\\U[0-9A-Fa-f]{8}</string>
 							<key>name</key>
 							<string>constant.character.escape.c++</string>
 						</dict>
@@ -631,7 +631,7 @@
 						</dict>
 						<dict>
 							<key>match</key>
-							<string>\\x\h+</string>
+							<string>\\x[0-9A-Fa-f]+</string>
 							<key>name</key>
 							<string>constant.character.escape.c++</string>
 						</dict>

--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -95,10 +95,10 @@
 			<key>match</key>
 			<string>(?x)\b
 			(  (?i:
-			      0x ( \h+    ( ' \h+    )* )?  # Hexadecimal
-			   |  0b ( [0-1]+ ( ' [0-1]+ )* )?  # Binary
-			   |  0  ( [0-7]+ ( ' [0-7]+ )* )   # Octal
-			   |     ( [0-9]+ ( ' [0-9]+ )* )   # Decimal
+			      0x ( [0-9A-Fa-f]+ ( ' [0-9A-Fa-f]+ )* )?  # Hexadecimal
+			   |  0b ( [0-1]+       ( ' [0-1]+ )* )?        # Binary
+			   |  0  ( [0-7]+       ( ' [0-7]+ )* )         # Octal
+			   |     ( [0-9]+       ( ' [0-9]+ )* )         # Decimal
 			   )
 			   ( ([uUfF] | u?ll? | U?LL?)\b | (?&lt;inc&gt;') | \b )
 			|  ( [0-9]+ ( ' [0-9]+ )* )?


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.