### PR TITLE
Remove hideFromUser invalid key

### DIFF
--- a/Syntaxes/Platform.tmLanguage
+++ b/Syntaxes/Platform.tmLanguage
@@ -6,8 +6,6 @@
 	<string>This file was generated with clang-C using MacOSX10.12.sdk</string>
 	<key>fileTypes</key>
 	<array/>
-	<key>hideFromUser</key>
-	<true/>
 	<key>name</key>
 	<string>Platform</string>
 	<key>patterns</key>


### PR DESCRIPTION
Is the `hideFromUser` serving any purpose? It's detected as invalid on GitHub.com and throwing errors (see github/linguist#3924 for further details).