### PR TITLE
Add pattern for ‘if constexpr’

### DIFF
--- a/Syntaxes/C++.plist
+++ b/Syntaxes/C++.plist
@@ -34,6 +34,23 @@
 			<string>#strings</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.c++</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.c++</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>\b(if)\s+(constexpr)\b</string>
+		</dict>
+		<dict>
 			<key>include</key>
 			<string>source.c</string>
 		</dict>


### PR DESCRIPTION
cc @infininight 

Current highlighting is like a variable name rather than a control flow keyword:
```c++
if constexpr (foo == 3) {
}
```
<img src="https://user-images.githubusercontent.com/14237/43688612-de04e186-98a0-11e8-9803-91c2b7ab484d.png" width="200">
