### PR TITLE
Support ‘template’ disambiguator

### DIFF
--- a/Syntaxes/C++.plist
+++ b/Syntaxes/C++.plist
@@ -51,6 +51,25 @@
 			<string>\b(if)\s+(constexpr)\b</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>punctuation.separator.scope.c++</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>comment</key>
+					<string>https://en.cppreference.com/w/cpp/language/dependent_name</string>
+					<key>name</key>
+					<string>storage.modifier.template.c++</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(::)\s*(template)\b</string>
+		</dict>
+		<dict>
 			<key>include</key>
 			<string>source.c</string>
 		</dict>

--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -456,12 +456,19 @@
 				</dict>
 				<key>2</key>
 				<dict>
+					<key>comment</key>
+					<string>https://en.cppreference.com/w/cpp/language/dependent_name</string>
+					<key>name</key>
+					<string>storage.modifier.template.c++</string>
+				</dict>
+				<key>3</key>
+				<dict>
 					<key>name</key>
 					<string>variable.other.dot-access.c</string>
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(\.|\-&gt;)([a-zA-Z_][a-zA-Z_0-9]*)\b(?!\s*\()</string>
+			<string>(\.|\-&gt;)(?:\s*(template)\s+)?([a-zA-Z_][a-zA-Z_0-9]*)\b(?!\s*\()</string>
 		</dict>
 		<key>block</key>
 		<dict>


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/language/dependent_name
```c++
{
  typename T::template iterator<int>::value_type v;
  s.template foo<T>();
  p->template foo<T>();
}
```