### PR TITLE
Improve new/delete operators

### DIFF
--- a/Syntaxes/C.plist
+++ b/Syntaxes/C.plist
@@ -392,7 +392,7 @@
     		       | (?= \s*[A-Za-z_] ) (?&lt;!&amp;&amp;)       (?&lt;=[*&amp;&gt;])   #  or type modifier before name
     		     )
     		)
-    		(\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate)\s*\()
+    		(\s*) (?!(while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate|(?:::)?new|(::)?delete)\s*\()
     		(
     			(?: [A-Za-z_][A-Za-z0-9_]*+ | :: )++ |                  # actual name
     			(?: (?&lt;=operator) (?: [-*&amp;&lt;&gt;=+!]+ | \(\) | \[\] ) )  # if it is a C++ operator
@@ -601,7 +601,7 @@
 			<key>match</key>
 			<string>(?x) (?: (?= \s )  (?:(?&lt;=else|new|return) | (?&lt;!\w)) (\s+))?
 			(\b 
-				(?!(while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate)\s*\()(?:(?!NS)[A-Za-z_][A-Za-z0-9_]*+\b | :: )++                  # actual name
+				(?!(while|for|do|if|else|switch|catch|enumerate|return|sizeof|[cr]?iterate|(?:::)?new|(::)?delete)\s*\()(?:(?!NS)[A-Za-z_][A-Za-z0-9_]*+\b | :: )++                  # actual name
 			)
 			 \s*(\()</string>
 			<key>name</key>


### PR DESCRIPTION
Support for placement-new and `::new`/`::delete` forms (by modifying the C grammar to not capture these as function names).
```c++
  delete x;
  ::delete x;
  delete[] x;
  ::delete[] x;
  new x;
  ::new x;
  new (y) x;
  ::new (y) x;
```