### PR TITLE
Default to honoring `.clang-format` file, if present

### DIFF
--- a/Commands/Reformat Document.tmCommand
+++ b/Commands/Reformat Document.tmCommand
@@ -6,7 +6,7 @@
 	<string>nop</string>
 	<key>command</key>
 	<string>#!/bin/bash
-if ! "${TM_CLANG_FORMAT}" -style="${TM_CLANG_FORMAT_STYLE:-LLVM}" -assume-filename="${TM_FILEPATH}"; then
+if ! "${TM_CLANG_FORMAT}" -style="${TM_CLANG_FORMAT_STYLE:-file}" -assume-filename="${TM_FILEPATH}"; then
 	. "$TM_SUPPORT_PATH/lib/bash_init.sh"
 	exit_show_tool_tip
 fi


### PR DESCRIPTION
If a file `.clang-format` is not present in one of the parent directories (determined by `--assume-filename`), it will default to use the LLVM style.