### PR TITLE
Add .hxx as a possible C++ header file extension

### DIFF
--- a/Syntaxes/C++.plist
+++ b/Syntaxes/C++.plist
@@ -15,6 +15,7 @@
 		<string>h</string>
 		<string>hh</string>
 		<string>hpp</string>
+		<string>hxx</string>
 		<string>h++</string>
 	</array>
 	<key>firstLineMatch</key>


### PR DESCRIPTION
This PR simply adds `.hxx` to the possible list of C++ header file extensions. I came across a C++ header file ending in `.hxx` which wasn't detected as C++ by TextMate, hence the addition.

Reference from vim: https://github.com/vim/vim/blob/a6c27c47ddf081859659d7de1caec675147e466b/runtime/filetype.vim#L291